### PR TITLE
Filter ajaxify

### DIFF
--- a/app/javascript/components/filter_categories.js
+++ b/app/javascript/components/filter_categories.js
@@ -1,21 +1,48 @@
-// const getCategories = () => {
-//   const categoriesJSON = document.querySelector('[data-categories]').dataset['categories'];
-//   return JSON.parse(categoriesJSON);
-// }
-
-const getSelectedCategoryName = () => {
-  const categories = document.querySelectorAll('.categories-list__item');
-  categories.forEach((category) => {
-    category.addEventListener('click', (event) => {
-      const selectedCategory = event.currentTarget;
-      return selectedCategory.dataset['name'];
+// Returns IDs of selected categories as array of strings
+const filterCategories = (categories) => {
+  let selectedCategoryIds = [];
+  categories.forEach(category => {
+    category.addEventListener("click", (event) => {
+      const selectedCategoryId = parseInt(event.currentTarget.dataset["id"]);
+      if (selectedCategoryIds.includes(selectedCategoryId)) {
+        selectedCategoryIds = selectedCategoryIds.filter(id => id != selectedCategoryId);
+      } else {
+        selectedCategoryIds.push(selectedCategoryId);
+      }
+      console.log(selectedCategoryIds);
+      filterSpots(selectedCategoryIds);
     });
   });
 }
 
-const filterByCategories = (selectedCategoryName) => {
-  const spotsRender = document.getElementById('spots-render');
-  // spotsRender.innerHTML = `<%= render @spots.in_category(${selectedCategoryName}) %>`
+
+const filterSpots = (selectedCategoryIds) => {
+  console.log("now it works a little bit more");
+  // filter spots and insert html for each spot into #spot__card
+  const spotsDiv = document.getElementById("spot__card");
+  spotsDiv.innerHTML = '';
+  const spotsJSON = document.querySelector("[data-spots]");
+  const spots = JSON.parse(spotsJSON.dataset["spots"]);
+  const filteredSpots = spots.filter(spot => {
+    console.log("and... a little bit more");
+    return selectedCategoryIds.includes(spot.category_id);
+  });
+  filteredSpots.forEach(spot => {
+
+    const spotCodeStart = "<div class='spots__card-wrapper'><div class='spot-card'>";
+    const spotLink = `<a class="spot-card__link-wrapper" href="/spots/${spot.id}">`;
+    const spotImg = `<img class="spot-card__image" src="${spot.photo['url']}">`;
+    const spotText = "<div class='spot-card__text'>";
+    const spotSubCat = `<p class="spot-card__sub-category">${spot.sub_category}</p>`;
+    const spotHeader = `<p class="spot-card__header">${spot.name}</p>`;
+    const spotCodeEnd = "</div></a></div></div>";
+
+    const spotCode = spotCodeStart + spotLink + spotImg + spotText + spotSubCat + spotHeader + spotCodeEnd;
+    spotsDiv.insertAdjacentHTML("afterbegin", spotCode);
+  });
 }
 
-export { getSelectedCategoryName, filterByCategories };
+export { filterCategories }
+
+
+

--- a/app/javascript/components/filter_categories.js
+++ b/app/javascript/components/filter_categories.js
@@ -1,0 +1,21 @@
+// const getCategories = () => {
+//   const categoriesJSON = document.querySelector('[data-categories]').dataset['categories'];
+//   return JSON.parse(categoriesJSON);
+// }
+
+const getSelectedCategoryName = () => {
+  const categories = document.querySelectorAll('.categories-list__item');
+  categories.forEach((category) => {
+    category.addEventListener('click', (event) => {
+      const selectedCategory = event.currentTarget;
+      return selectedCategory.dataset['name'];
+    });
+  });
+}
+
+const filterByCategories = (selectedCategoryName) => {
+  const spotsRender = document.getElementById('spots-render');
+  // spotsRender.innerHTML = `<%= render @spots.in_category(${selectedCategoryName}) %>`
+}
+
+export { getSelectedCategoryName, filterByCategories };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,12 +6,19 @@ import { initAutocomplete } from "../plugins/init_autocomplete";
 import { initCloudinary } from "../plugins/init_cloudinary";
 import ToggleMapView from "../components/toggle_map_view";
 import Filters from "../components/filters";
+import { filterCategories } from "../components/filter_categories";
 
 document.addEventListener("DOMContentLoaded", initGetAvatar);
 
 initMapbox();
 initAutocomplete();
 initCloudinary();
+
+const allCategories = document.querySelectorAll("[data-id]");
+if (allCategories) {
+  console.log("it kinda works");
+  filterCategories(allCategories);
+}
 
 new ToggleMapView();
 new Filters();

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,7 +1,7 @@
 class City < ApplicationRecord
   mount_uploader :cover, CityCoverUploader
 
-  has_many :spots
+  has_many :spots, dependent: :destroy
   has_and_belongs_to_many :keepers, class_name: "User"
 
   validates :name, presence: true, uniqueness: true

--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -12,7 +12,7 @@
     <ul class="categories-list">
       <% Category.all.each do |category| %>
         <li class="categories-list__item">
-          <div class="categories-list__icon">
+          <div class="categories-list__icon" data-id="<%= category.id %>">
             <%= show_svg("placemark_#{category.name}.svg") %>
           </div>
           <%= link_to category.name.capitalize, city_spots_path(category: category.name), class: "categories-list__name" %>

--- a/app/views/spots/_spot_card.html.erb
+++ b/app/views/spots/_spot_card.html.erb
@@ -1,9 +1,15 @@
-<div class="spot-card">
-  <%= link_to spot_path(spot), class: "spot-card__link-wrapper" do %>
-    <%= cl_image_tag((spot.photo? ? spot.photo.card : spot.city.cover.card), class: "spot-card__image") %>
-    <div class="spot-card__text">
-      <p class="spot-card__sub-category"><%= spot.sub_category %></p>
-      <p class="spot-card__header"><%= spot.name %></p>
+<div class="spots__cards">
+  <% spots.each do |spot| %>
+    <div class="spots__card-wrapper">
+      <div class="spot-card">
+        <%= link_to spot_path(spot), class: "spot-card__link-wrapper" do %>
+          <%= cl_image_tag((spot.photo? ? spot.photo.card : spot.city.cover.card), class: "spot-card__image") %>
+          <div class="spot-card__text">
+            <p class="spot-card__sub-category"><%= spot.sub_category %></p>
+            <p class="spot-card__header"><%= spot.name %></p>
+          </div>
+        <% end %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -27,13 +27,9 @@
     <div class="spots__overlay hide js-map-overlay">
       <%= render "shared/map" %>
     </div>
-    <div class="spots__cards">
-      <% @spots.each do |spot| %>
-        <div class="spots__card-wrapper">
-          <%= render partial: "spots/spot_card", locals: { spot: spot} %>
-        </div>
-      <% end %>
-    </div>
+    <div style="display: none" data-spots="<%= @spots.to_json %>"></div>
+      <%= render partial: "spots/spot_card", locals: { spots: @spots} %>
+      <div class="spots__cards" id="spot__card"></div>
     <div class="spots__pagination">
       <%= render partial: "shared/pagination", locals: { pagy: @pagy } %>
     </div>


### PR DESCRIPTION
Spots can be filtered without going to a new page, by clicking the filter icon (instead of text). This is a preview of the feature and further work on the following is still needed:
-- implementing CSS to show which filters have been selected
-- removing double display of spot listings (currently left that way for comparison of old/new filter)
-- enabling users with JS disabled to still navigate the site