### PR TITLE
Update .env-example

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -37,12 +37,12 @@ Sign up at https://cloudinary.com/
 
 ### GitHub
 
-1. Go to https://github.com/settings/apps
-2. Click "New GitHub App"
+1. Go to https://github.com/settings/developers
+2. Click "New OAuth App"
 3. Fill in the following fields:
 
-**GitHub App Name:** _Any Name You Want_
+**Application name:** _Any Name You Want_
 
 **Homepage URL:** http://localhost:3000
 
-**User authorization callback URL:** http://localhost:3000/users/auth/github/callback
+**Authorization callback URL:** http://localhost:3000/users/auth/github/callback


### PR DESCRIPTION
The description that was provided to link github authorization didn't work for me. I had to make a new **OAuth App** instead of a **GitHub App**. After doing that it now works. 

I updated the documentation in this file.