### PR TITLE
Change 'Name' to 'City Name' on Add new spot page

### DIFF
--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -2,7 +2,7 @@
   <% if @spot.persisted? %>
     <%= f.input :status, as: :radio_buttons, collection: [["draft", "Draft"], ["published", "Published"]], label_method: :second, value_method: :first %>
   <% end %>
-  <%= f.input :name, input_html: { autocomplete: "off" } %>
+  <%= f.input :name, label: 'City Name', input_html: { autocomplete: "off" } %>
   <%= render partial: "spots/autocomplete_dropdown" %>
   <%= f.association :category %>
   <%= f.input :sub_category %>


### PR DESCRIPTION
Input field [Name]  - With a 'Name', it can be understand as name of user, name of spot, name of city. So to make it clear, change the field name to [City name]