### PR TITLE
'Name' change to 'spot name' on new spot page

### DIFF
--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -2,7 +2,7 @@
   <% if @spot.persisted? %>
     <%= f.input :status, as: :radio_buttons, collection: [["draft", "Draft"], ["published", "Published"]], label_method: :second, value_method: :first %>
   <% end %>
-  <%= f.input :name, label: 'City Name', input_html: { autocomplete: "off" } %>
+  <%= f.input :name, label: 'Spot Name', input_html: { autocomplete: "off" } %>
   <%= render partial: "spots/autocomplete_dropdown" %>
   <%= f.association :category %>
   <%= f.input :sub_category %>
@@ -27,4 +27,3 @@
                       input_html: { class: "button--file-upload" } %>
   <%= f.submit class: "button button--big button--primary" %>
 <% end %>
-

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -2,7 +2,7 @@
   <% if @spot.persisted? %>
     <%= f.input :status, as: :radio_buttons, collection: [["draft", "Draft"], ["published", "Published"]], label_method: :second, value_method: :first %>
   <% end %>
-  <%= f.input :name, input_html: { autocomplete: "off" } %>
+  <%= f.input :name, label: 'City Name', input_html: { autocomplete: "off" } %>
   <%= render partial: "spots/autocomplete_dropdown" %>
   <%= f.association :category %>
   <%= f.input :sub_category %>


### PR DESCRIPTION
On a new spot page, first field name [Name] can be understand as user name, city name and spot name. So change it to [Spot name] to make it clear.