### PR TITLE
City no spots v2

### DIFF
--- a/app/assets/stylesheets/pages/_spots.scss
+++ b/app/assets/stylesheets/pages/_spots.scss
@@ -9,7 +9,17 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding-bottom: $spacing-48;
+  padding-bottom: $spacing-12;
+}
+
+@media screen and (min-width: 576px) {
+  .spots__message-wrapper {
+    padding-bottom: $spacing-48;
+  }
+
+  .spots__message {
+    width: 545px;
+  }
 }
 
 .spots__message {

--- a/app/assets/stylesheets/pages/_spots.scss
+++ b/app/assets/stylesheets/pages/_spots.scss
@@ -5,6 +5,15 @@
 .spots__message-wrapper {
   @include wrapper();
   @include spacer();
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.spots__message {
+  text-align: center;
+  margin: $spacing-5 0px;
 }
 
 .spots__map-button {

--- a/app/assets/stylesheets/pages/_spots.scss
+++ b/app/assets/stylesheets/pages/_spots.scss
@@ -9,11 +9,16 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  padding-bottom: $spacing-48;
 }
 
 .spots__message {
   text-align: center;
   margin: $spacing-5 0px;
+}
+
+.spots__button {
+  margin: $spacing-3 0px;
 }
 
 .spots__map-button {

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -5,7 +5,7 @@ class CitiesController < ApplicationController
   before_action :set_keepers, only: [:create, :update]
 
   def index
-    @cities = policy_scope(City).alphabetize
+    @cities = policy_scope(City).with_published_spots.alphabetize
   end
 
   def new

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -5,7 +5,7 @@ class CitiesController < ApplicationController
   before_action :set_keepers, only: [:create, :update]
 
   def index
-    @cities = policy_scope(City).with_published_spots.alphabetize
+    @cities = policy_scope(City).alphabetize
   end
 
   def new

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,7 +1,7 @@
 class City < ApplicationRecord
   mount_uploader :cover, CityCoverUploader
 
-  has_many :spots
+  has_many :spots, dependent: :destroy
   has_and_belongs_to_many :keepers, class_name: "User"
   belongs_to :country
 

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -6,8 +6,16 @@
   </header>
   <% if @city.spots.blank? %>
     <div class="spots__message-wrapper">
-      <p class="spots__message">Oh, oops! No spots for <strong><%= @city.name %></strong> have been added yet. 💩</p>
-      <%= link_to "Share one now", new_spot_path, class: "button button--primary" %>
+      <h2 class="spots__message"><span class="highlight highlight--purple">
+        Sorry,</span> there are no hot spots
+        <br>listed for this city yet.
+      </h2>
+      <p class="spots__message">
+        Feel free to add your personal hot spots now, so that this list
+        <br>doesn't stay empty for long. Otherwise feel free to select a
+        <br>different category or city.
+      </p>
+      <%= link_to "Share one now", new_spot_path, class: "button button--primary button--big" %>
     </div>
   <% else %>
     <div class="spots__main">

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -15,7 +15,8 @@
         <br>doesn't stay empty for long. Otherwise feel free to select a
         <br>different category or city.
       </p>
-      <%= link_to "Share one now", new_spot_path, class: "button button--primary button--big" %>
+      <%= link_to "Share your 🔥 spots", new_spot_path, class: "button button--secondary button--big spots__button" %>
+      <%= link_to "Take me back", root_path, class: "button button--primary button--big spots__button" %>
     </div>
   <% else %>
     <div class="spots__main">

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -8,12 +8,12 @@
     <div class="spots__message-wrapper">
       <h2 class="spots__message"><span class="highlight highlight--purple">
         Sorry,</span> there are no hot spots
-        <br>listed for this city yet.
+        listed for this city yet.
       </h2>
       <p class="spots__message">
         Feel free to add your personal hot spots now, so that this list
-        <br>doesn't stay empty for long. Otherwise feel free to select a
-        <br>different category or city.
+        doesn't stay empty for long. Otherwise feel free to select a
+        different category or city.
       </p>
       <%= link_to "Share your 🔥 spots", new_spot_path, class: "button button--secondary button--big spots__button" %>
       <%= link_to "Take me back", root_path, class: "button button--primary button--big spots__button" %>


### PR DESCRIPTION
- For city_no-spots page to appear, with_published_spots in @cities from cities#index must be removed.
- city_no-spots page (desktop) created and optimized for mobile (no Figma design for mobile available for reference)

Other notable changes:
- dependent: :destroy has been added for spots in City model